### PR TITLE
Fix: Resolve ReferenceError for 'databases' in TripContext

### DIFF
--- a/app/(UserOnly)/addTrip.jsx
+++ b/app/(UserOnly)/addTrip.jsx
@@ -45,7 +45,7 @@ const addTrip = () => {
                 date,
                 startHour,
                 endHour,
-                price,
+                price: parseInt(price, 10),
             });
 
             setStartLocation("");

--- a/contexts/TripContext.jsx
+++ b/contexts/TripContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useState } from "react";
 import { ID, Permission, Role } from "react-native-appwrite";
 import { useUser } from "../hooks/useUser";
+import { databases } from "../lib/appwrite";
 
 export const TripContext = createContext();
 


### PR DESCRIPTION
Imported the 'databases' object from the Appwrite configuration into TripContext.jsx to resolve a ReferenceError that occurred when trying to add a new trip. The 'databases' object was being used without being defined in the context.